### PR TITLE
added e2e tests, some minor response parsing fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ test.py
 *.pyc
 *.idea/
 .DS_Store
+test_data
+!test_data/andorra-latest.osm.pbf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## **Unreleased**
 
+### Added
+- Added e2e tests using dockerized instances of Valhalla, OSRM, ORS and GraphHopper
+
+### Fixed
+- Valhalla's Isochrones center property was unnecessarily wrapped in a list
+- GraphHopper Isochrones center coordinates were strings, not floats
+
 ## [v1.1.0](https://pypi.org/project/routingpy/1.1.0/)
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,9 @@ poetry install
 ```
 
 3. Run tests to check if all goes well:
+
+(In order to run the e2e tests, run the router instances with `docker-compose up` from the project root)
+
 ```bash
 # From the root of your git project
 nosetests -v
@@ -62,10 +65,9 @@ pre-commit install
 
 ### Tests
 
-We only do mocked tests as routing results heavily depend on underlying data, which, at least in the case of the FOSS routing
-engines, changes on a very regular basis due to OpenStreetMap updates. All queries and most mocked responses are located in
-`test/test_helper.py` in `dict`s. This unfortunately also means, that our tests are less API tests and more unit tests and can't catch
-updates on providers' API changes.
+~~We only do mocked tests as routing results heavily depend on underlying data, which, at least in the case of the FOSS routing
+engines, changes on a very regular basis due to OpenStreetMap updates.~~ We also do end-to-end testing now! Run `docker-compose up` from
+the project root to set up local instances of Valhalla, OSRM, ORS and GraphHopper!
 
 Run `nosetests` with a `coverage` flag, which shouldn't report < 90% coverage overall (the starting point at the
 beginning of the project). A [`coveralls.io`](https://coveralls.io) instance will check for coverage when you submit a PR.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+version: "3.8"
+services:
+    ors:
+        container_name: ors-tests
+        ports:
+            - "8080:8080"
+        image: ghcr.io/gis-ops/openrouteservice:latest
+        volumes:
+            - ./test_data/andorra-latest.osm.pbf:/ors-core/data/osm_file.pbf
+        environment:
+            - "JAVA_OPTS=-Djava.awt.headless=true -server -XX:TargetSurvivorRatio=75 -XX:SurvivorRatio=64 -XX:MaxTenuringThreshold=3 -XX:+UseG1GC -XX:+ScavengeBeforeFullGC -XX:ParallelGCThreads=4 -Xms1g -Xmx2g"
+            - "CATALINA_OPTS=-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9001 -Dcom.sun.management.jmxremote.rmi.port=9001 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=localhost"
+    valhalla:
+        container_name: valhalla-tests
+        image: gisops/valhalla:latest
+        ports:
+            - "8002:8002"
+        volumes:
+            - ./test_data/:/custom_files
+    osrm:
+        container_name: osrm-tests
+        image: osrm/osrm-backend:latest
+        ports:
+            - "5000:5000"
+        volumes:
+            - ./test_data/:/data
+        command: '/bin/bash -c "osrm-extract -p /opt/car.lua /data/andorra-latest.osm.pbf && osrm-partition /data/andorra-latest.osrm && osrm-customize /data/andorra-latest.osrm && osrm-routed --algorithm=MLD /data/andorra-latest.osrm"'
+    graphhopper:
+        container_name: graphhopper-tests
+        image: israelhikingmap/graphhopper:latest
+        ports:
+            - "8989:8989"
+        volumes:
+            - ./test_data/:/graphhopper/data
+        command: "-i data/andorra-latest.osm.pbf --host 0.0.0.0"

--- a/routingpy/routers/graphhopper.py
+++ b/routingpy/routers/graphhopper.py
@@ -510,7 +510,7 @@ class Graphhopper:
             type,
             intervals[0],
             buckets,
-            center,
+            locations,
             interval_type,
         )
 

--- a/routingpy/routers/valhalla.py
+++ b/routingpy/routers/valhalla.py
@@ -519,7 +519,7 @@ class Valhalla:
                     Isochrone(
                         geometry=feature["geometry"]["coordinates"],
                         interval=intervals[idx],
-                        center=locations,
+                        center=locations[0],
                         interval_type=interval_type,
                     )
                 )

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,0 +1,145 @@
+import tests as _test
+from routingpy import ORS, OSRM, Graphhopper, Valhalla
+
+
+class TestRoutingpyE2e(_test.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.valhalla = Valhalla("http://localhost:8002")
+        cls.osrm = OSRM("http://localhost:5000")
+        cls.ors = ORS(base_url="http://localhost:8080/ors")
+        cls.gh = Graphhopper(base_url="http://localhost:8989")
+
+    def test_valhalla_directions(self):
+
+        directions = self.valhalla.directions(
+            [
+                [1.51886, 42.5063],
+                [1.53789, 42.51007],
+            ],
+            "auto",
+        )
+
+        self.assertIsInstance(directions.geometry, list)
+        self.assertIsInstance(directions.duration, int)
+        self.assertIsInstance(directions.distance, int)
+
+    def test_valhalla_isochrones(self):
+
+        isochrones = self.valhalla.isochrones(
+            [
+                [1.51886, 42.5063],
+            ],
+            "auto",
+            [20, 50],
+        )
+
+        self.assertIsInstance(isochrones[1].geometry, list)
+        self.assertEqual(isochrones[0].interval, 20)
+        self.assertEqual(isochrones[1].interval, 50)
+        self.assertEqual(isochrones[1].center, [1.51886, 42.5063])
+
+    def test_valhalla_matrix(self):
+        matrix = self.valhalla.matrix(
+            [
+                [1.51886, 42.5063],
+                [1.53789, 42.51007],
+                [1.53489, 42.52007],
+                [1.53189, 42.51607],
+            ],
+            "auto",
+        )
+
+        self.assertEqual(len(matrix.distances), 4)
+        self.assertEqual(len(matrix.durations), 4)
+        self.assertEqual(len(matrix.durations[0]), 4)
+        self.assertEqual(len(matrix.distances[0]), 4)
+
+    def test_osrm_directions(self):
+        directions = self.osrm.directions(
+            [
+                [1.51886, 42.5063],
+                [1.53789, 42.51007],
+            ]
+        )
+
+        self.assertIsInstance(directions.geometry, list)
+        self.assertIsInstance(directions.duration, int)
+        self.assertIsInstance(directions.distance, int)
+
+    def test_osrm_matrix(self):
+        matrix = self.osrm.matrix(
+            [
+                [1.51886, 42.5063],
+                [1.53789, 42.51007],
+                [1.53489, 42.52007],
+                [1.53189, 42.51607],
+            ],
+            "auto",
+        )
+
+        self.assertEqual(len(matrix.distances), 4)
+        self.assertEqual(len(matrix.durations), 4)
+        self.assertEqual(len(matrix.durations[0]), 4)
+        self.assertEqual(len(matrix.distances[0]), 4)
+
+    def test_ors_directions(self):
+        directions = self.ors.directions(
+            [
+                [1.51886, 42.5063],
+                [1.53789, 42.51007],
+            ],
+            "driving-car",
+        )
+
+        self.assertIsInstance(directions.geometry, list)
+        self.assertIsInstance(directions.duration, int)
+        self.assertIsInstance(directions.distance, int)
+
+    def test_ors_isochrones(self):
+        isochrones = self.ors.isochrones([1.51886, 42.5063], "driving-car", [20, 50])
+
+        self.assertIsInstance(isochrones[1].geometry, list)
+        self.assertEqual(isochrones[0].interval, 20)
+        self.assertEqual(isochrones[1].interval, 50)
+        self.assertAlmostEqual(isochrones[1].center[0], 1.51886, 1)
+        self.assertAlmostEqual(isochrones[1].center[1], 42.5063, 1)
+
+    def test_ors_matrix(self):
+        matrix = self.ors.matrix(
+            [
+                [1.51886, 42.5063],
+                [1.53789, 42.51007],
+                [1.53489, 42.52007],
+                [1.53189, 42.51607],
+            ],
+            "driving-car",
+            metrics=["distance", "duration"],
+        )
+
+        self.assertEqual(len(matrix.distances), 4)
+        self.assertEqual(len(matrix.durations), 4)
+        self.assertEqual(len(matrix.durations[0]), 4)
+        self.assertEqual(len(matrix.distances[0]), 4)
+
+    def test_graphhopper_directions(self):
+        directions = self.gh.directions(
+            [
+                [1.51886, 42.5063],
+                [1.53789, 42.51007],
+            ],
+            "car",
+        )
+
+        self.assertIsInstance(directions.geometry, list)
+        self.assertIsInstance(directions.duration, int)
+        self.assertIsInstance(directions.distance, int)
+
+    def test_graphhopper_isochrones(self):
+        isochrones = self.gh.isochrones([1.51886, 42.5063], "car", [50])
+
+        self.assertIsInstance(isochrones[0].geometry, list)
+        self.assertEqual(isochrones[0].interval, 50)
+        print(isochrones[0].center)
+        self.assertAlmostEqual(isochrones[0].center[0], 1.51886, 1)
+        self.assertAlmostEqual(isochrones[0].center[1], 42.5063, 1)


### PR DESCRIPTION
I left the mocked request tests for now, because a) we still need them for non-FOSS routers and b) they do help with testing the parsing and request building. For now, the e2e tests are also just pretty basic, we can add more sophisticated ones as time moves on, what do you think @nilsnolde ?