### PR TITLE
Fix Graphhopper POST

### DIFF
--- a/routingpy/routers/graphhopper.py
+++ b/routingpy/routers/graphhopper.py
@@ -272,9 +272,8 @@ class Graphhopper:
 
         params = {"vehicle": profile}
 
-        for coordinate in locations:
-            coord_lnglat = ([convert.format_float(f) for f in coordinate])
-            params["points"] = ",".join(coord_lnglat)
+        if locations is not None:
+            params["points"] = locations
 
         get_params = {}
 

--- a/routingpy/routers/graphhopper.py
+++ b/routingpy/routers/graphhopper.py
@@ -264,7 +264,7 @@ class Graphhopper:
            `snap_prevention` to `snap_preventions`, `curb_side` to `curbsides`,
 
         .. versionadded:: 1.2.0
-           `custom_model` parameters
+           Added `custom_model` parameter
 
         .. deprecated:: 1.2.0
            Removed `weighting`, `block_area`, `avoid`, `turn_costs` parameters

--- a/routingpy/routers/graphhopper.py
+++ b/routingpy/routers/graphhopper.py
@@ -276,8 +276,10 @@ class Graphhopper:
             coord_lnglat = ([convert.format_float(f) for f in coordinate])
             params["points"] = ",".join(coord_lnglat)
 
+        get_params = {}
+
         if self.key is not None:
-            params["key"] = self.key
+            get_params["key"] = self.key
 
         if format is not None:
             params["type"] = format
@@ -358,7 +360,7 @@ class Graphhopper:
         params.update(direction_kwargs)
 
         return self.parse_directions_json(
-            self.client._request("/route", post_params=params, dry_run=dry_run),
+            self.client._request("/route", get_params=get_params, post_params=params, dry_run=dry_run),
             algorithm,
             elevation,
             points_encoded,

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -1091,8 +1091,11 @@ ENDPOINTS_EXPECTED = {
     "graphhopper": {
         "directions": {
             "vehicle": "car",
-            "points": "8.780916,49.445776",
-            "key": "sample_key",
+            "points": [
+                [8.688641, 49.420577],
+                [8.680916, 49.415776],
+                [8.780916, 49.445776]
+            ],
             "type": "json",
             "optimize": True,
             "instructions": False,
@@ -1101,37 +1104,20 @@ ENDPOINTS_EXPECTED = {
             "points_encoded": True,
             "calc_points": False,
             "debug": True,
-            "point_hints": [
-                "OSM Street",
-                "Graphhopper Lane",
-                "Routing Broadway"
-            ],
-            "snap_preventions": [
-                "trunk",
-                "ferry"
-            ],
-            "curbsides": [
-                "any",
-                "right"
-            ],
-            "details": [
-                "tolls",
-                "time"
-            ],
+            "point_hints": ["OSM Street", "Graphhopper Lane", "Routing Broadway"],
+            "snap_preventions": ["trunk", "ferry"],
+            "curbsides": ["any", "right"],
+            "details": ["tolls", "time"],
             "ch.disable": True,
             "custom_model": {
-                "speed": [
-                    {
-                        "if": "true",
-                        "limit_to": "100"
-                    }
-                ],
-                "priority": [
-                    {
-                        "if": "road_class == MOTORWAY",
-                        "multiply_by": "0"
-                    }
-                ],
+                "speed": [{
+                    "if": "true",
+                    "limit_to": "100"
+                }],
+                "priority": [{
+                    "if": "road_class == MOTORWAY",
+                    "multiply_by": "0"
+                }],
                 "distance_influence": 100
             },
             "heading_penalty": 100,


### PR DESCRIPTION
This fixes two bugs in #91:

1. `key` should be a GET parameter, not POST according to the [docs](https://docs.graphhopper.com/#operation/postRoute)
2.  Coordinates should be numbers, not strings