### PR TITLE
fix: content-type issue

### DIFF
--- a/routingpy/client_default.py
+++ b/routingpy/client_default.py
@@ -229,7 +229,10 @@ class Client(BaseClient):
         content_type = response.headers["content-type"]
 
         if status_code == 200:
-            if content_type in ["application/json", "application/x-www-form-urlencoded"]:
+            if content_type == "image/tiff":
+                return response.content
+
+            else:
                 try:
                     return response.json()
 
@@ -237,12 +240,6 @@ class Client(BaseClient):
                     raise exceptions.JSONParseError(
                         "Can't decode JSON response:{}".format(response.text)
                     )
-
-            elif content_type == "image/tiff":
-                return response.content
-
-            else:
-                raise exceptions.UnsupportedContentType(status_code, response.text)
 
         if status_code == 429:
             raise exceptions.OverQueryLimit(status_code, response.text)

--- a/routingpy/exceptions.py
+++ b/routingpy/exceptions.py
@@ -71,9 +71,3 @@ class OverQueryLimit(RouterError, RetriableRequest):
     """
 
     pass
-
-
-class UnsupportedContentType(Exception):  # pragma: no cover
-    """The response has an unsupported content type."""
-
-    pass


### PR DESCRIPTION
Checking the content-type wasn't such a good idea after all. For example, Google returns "application/json; charset=utf-8".