### PR TITLE
Fixes taking into account the `preference` parameter when calculating isochrones and matrix with Valhalla

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## **Unreleased**
 
+### Fixed
+
+- Fixes taking into account the `preference` parameter when calculating isochrones and matrix with Valhalla ([#120](https://github.com/gis-ops/routingpy/issues/120))
+
 ## [v1.3.0](https://pypi.org/project/routingpy/1.3.0/)
 
 ### Added

--- a/routingpy/routers/valhalla.py
+++ b/routingpy/routers/valhalla.py
@@ -438,7 +438,7 @@ class Valhalla:
             "contours": contours,
         }
 
-        if options:
+        if options or preference:
             params["costing_options"] = dict()
             profile = profile if profile != "multimodal" else "transit"
             params["costing_options"][profile] = dict()
@@ -619,7 +619,7 @@ class Valhalla:
                 dest_coords = [dest_coords]
         params["targets"] = dest_coords
 
-        if options:
+        if options or preference:
             params["costing_options"] = dict()
             profile = profile if profile != "multimodal" else "transit"
             params["costing_options"][profile] = dict()

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -1077,7 +1077,7 @@ ENDPOINTS_QUERIES = {
             },
             "profile": "auto",
             "id": "wacko",
-            "preference": "fastest",
+            "preference": "shortest",
             "intervals": [600, 1200],
             "colors": ["ff0000", "00FF00"],
             "polygons": True,
@@ -1097,6 +1097,7 @@ ENDPOINTS_QUERIES = {
             "profile": "auto",
             "units": "mi",
             "id": "wacko",
+            "preference": "shortest",
         },
         "expansion": {
             "expansion_properties": ["distances", "durations", "costs"],
@@ -1210,7 +1211,12 @@ ENDPOINTS_EXPECTED = {
             "locations": [{"lat": PARAM_POINT[1], "lon": PARAM_POINT[0]}],
             "costing": "auto",
             "costing_options": {
-                "auto": {"maneuver_penalty": 50, "toll_booth_cost": 50, "country_crossing_penalty": 50}
+                "auto": {
+                    "maneuver_penalty": 50,
+                    "toll_booth_cost": 50,
+                    "country_crossing_penalty": 50,
+                    "shortest": True,
+                }
             },
             "contours": [{"time": 10, "color": "ff0000"}, {"time": 20, "color": "00FF00"}],
             "avoid_locations": [{"lon": 8.34234, "lat": 48.23424}],
@@ -1233,7 +1239,12 @@ ENDPOINTS_EXPECTED = {
             ],
             "costing": "auto",
             "costing_options": {
-                "auto": {"maneuver_penalty": 50, "toll_booth_cost": 50, "country_crossing_penalty": 50}
+                "auto": {
+                    "maneuver_penalty": 50,
+                    "toll_booth_cost": 50,
+                    "country_crossing_penalty": 50,
+                    "shortest": True,
+                }
             },
             "avoid_locations": [{"lon": 8.34234, "lat": 48.23424}],
             "id": "wacko",


### PR DESCRIPTION
Closes #120 (as pointed in https://github.com/gis-ops/routingpy/issues/120#issuecomment-1781261210 I took care of the matrix function which exhibited the same behavior as the isochrone one with regard to the `preference` parameter).

In the tests, I chose to modify the `ENDPOINTS_QUERIES` and `ENDPOINTS_EXPECTED` objects to include the `preference` parameter, rather than adding new tests specifically for this (but I can do it differently if you wish).