### PR TITLE
Add Support for Address String Input in Google Router's Directions Method

### DIFF
--- a/routingpy/routers/google.py
+++ b/routingpy/routers/google.py
@@ -262,11 +262,15 @@ class Google:
         origin, destination = locations[0], locations[-1]
         if isinstance(origin, (list, tuple)):
             params["origin"] = convert.delimit_list(list(reversed(origin)))
+        elif isinstance(origin, str):
+            params["origin"] = origin
         elif isinstance(origin, self.WayPoint):
             raise TypeError("The first and last locations must be list/tuple of [lon, lat]")
 
         if isinstance(destination, (list, tuple)):
             params["destination"] = convert.delimit_list(list(reversed(destination)))
+        elif isinstance(destination, str):
+            params["destination"] = destination
         elif isinstance(origin, self.WayPoint):
             raise TypeError("The first and last locations must be list/tuple of [lon, lat]")
 


### PR DESCRIPTION
This pull request addresses an inconsistency between the documentation and the functionality of the Google router's directions method. While the documentation suggests that it's possible to provide an address string instead of coordinates or waypoints, the current implementation doesn't support this. However, the Google Maps API does allow address strings.

To resolve this, I've implemented support for address strings in the directions method of the Google router. This enhancement aligns the functionality with the expected behavior outlined in the documentation.