### PR TITLE
Correct type hint

### DIFF
--- a/routingpy/matrix.py
+++ b/routingpy/matrix.py
@@ -31,7 +31,7 @@ class Matrix(object):
         self._raw = raw
 
     @property
-    def durations(self) -> Optional[List[List[float]]]:
+    def durations(self) -> Optional[List[List[Optional[float]]]]:
         """
         The durations matrix as list akin to::
 


### PR DESCRIPTION
I was wondering about a warning my IDE showed me. However I think it came from this type hint. As the durations matrix may have set some values to None (at least for Valhalla that is sometimes the case), the type hint should be a Optional list of lists of Optional floats.

If I'm wrong, please let me know about it and you can of course just close the PR.